### PR TITLE
add user(for unique identifier in each request) to the the models

### DIFF
--- a/lib/answer.dart
+++ b/lib/answer.dart
@@ -18,7 +18,8 @@ class AnswerApiParameters {
       this.logitBias,
       this.returnMetadata = false,
       this.returnPrompt = false,
-      this.expand}) {
+      this.expand,
+      this.user}) {
     if (documents == null && file == null) {
       throw ArgumentError(
           'Either the documents argument or the file argument needs to be provided.');
@@ -46,6 +47,7 @@ class AnswerApiParameters {
   final bool returnMetadata;
   final bool returnPrompt;
   final List<String>? expand;
+  final String? user;
 
   Map<String, dynamic> toJson() => _$AnswerApiParametersToJson(this);
 }

--- a/lib/answer.g.dart
+++ b/lib/answer.g.dart
@@ -33,6 +33,7 @@ Map<String, dynamic> _$AnswerApiParametersToJson(AnswerApiParameters instance) {
   val['return_metadata'] = instance.returnMetadata;
   val['return_prompt'] = instance.returnPrompt;
   writeNotNull('expand', instance.expand);
+  writeNotNull('user', instance.user);
   return val;
 }
 

--- a/lib/classification.dart
+++ b/lib/classification.dart
@@ -15,7 +15,8 @@ class ClassificationApiParameters {
       this.logitBias,
       this.returnPrompt = false,
       this.returnMetadata = false,
-      this.expand}) {
+      this.expand,
+      this.user}) {
     if (examples == null && file == null) {
       throw ArgumentError(
           'Either the examples argument or the file argument needs to be provided.');
@@ -39,6 +40,7 @@ class ClassificationApiParameters {
   final bool returnPrompt;
   final bool returnMetadata;
   final List<String>? expand;
+  final String? user;
 
   Map<String, dynamic> toJson() => _$ClassificationApiParametersToJson(this);
 }

--- a/lib/classification.g.dart
+++ b/lib/classification.g.dart
@@ -30,6 +30,7 @@ Map<String, dynamic> _$ClassificationApiParametersToJson(
   val['return_prompt'] = instance.returnPrompt;
   val['return_metadata'] = instance.returnMetadata;
   writeNotNull('expand', instance.expand);
+  writeNotNull('user', instance.user);
   return val;
 }
 

--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -16,7 +16,8 @@ class CompletionApiParameters {
       this.presencePenalty = 0,
       this.frequencyPenalty = 0,
       this.bestOf = 1,
-      this.logitBias});
+      this.logitBias,
+      this.user});
 
   final String prompt;
   final int maxTokens;
@@ -31,6 +32,7 @@ class CompletionApiParameters {
   final num frequencyPenalty;
   final int bestOf;
   final Map<String, num>? logitBias;
+  final String? user;
 
   Map<String, dynamic> toJson() => _$CompletionApiParametersToJson(this);
 }

--- a/lib/completion.g.dart
+++ b/lib/completion.g.dart
@@ -30,6 +30,7 @@ Map<String, dynamic> _$CompletionApiParametersToJson(
   val['frequency_penalty'] = instance.frequencyPenalty;
   val['best_of'] = instance.bestOf;
   writeNotNull('logit_bias', instance.logitBias);
+  writeNotNull('user', instance.user);
   return val;
 }
 


### PR DESCRIPTION
To help with monitoring for possible misuse, developers serving multiple end-users should pass an additional user parameter to OpenAI with each API call, in which user is a unique ID representing a particular end-user.